### PR TITLE
Update embed-public.js set timeout 5s reload iframe

### DIFF
--- a/js/embed-public.js
+++ b/js/embed-public.js
@@ -22,7 +22,14 @@ jQuery(function($) {
 		if (! isNativeViewer) {
 			$iframe.css('visibility', 'visible');
 		}
+
+		// fix so sometimes google doc viewer return 204 no content
+	    	timerId = setInterval(function () {
+	      		$("iframe.ead-iframe").attr("src", $activeIframe.attr("src"));
+	    	}, 5000);
+		
 		$iframe.on('load', function() {
+			clearInterval(timerId);
 			$(this).parents('.ead-document').find('.ead-document-loading').css('display', 'none');
 		});
 


### PR DESCRIPTION
Working on issue:
sometime google doc viewer return response 204 no content and page keep loading forever

![Screenshot from 2024-11-07 14-23-15](https://github.com/user-attachments/assets/5bb9fabb-d171-4b2a-9a9e-1b56c2083d83)


Like discussion link: 
https://stackoverflow.com/questions/40414039/google-docs-viewer-returning-204-responses-no-longer-working-alternatives
